### PR TITLE
Add prototype for tiered web directory data sources

### DIFF
--- a/tiered_directory/README.md
+++ b/tiered_directory/README.md
@@ -1,0 +1,50 @@
+# Tiered Web Directory
+
+This prototype aims to explore data sources and scraping approaches for building a tiered directory of the web.  
+
+## Goal
+Create a categorical and sub‑categorical system that ranks prominent websites into S/A/B/C/D/F tiers.  
+
+## Approach
+1. **Collect candidate sites** for each category using open data sources.  
+2. **Gather ranking signals** (traffic, backlinks, etc.) from available APIs.  
+3. **Assign tiers** based on thresholds or combined scores.  
+4. **Expose results** as a browsable directory.
+
+## Candidate Data Sources
+| Source | Type | Pros | Cons |
+|-------|------|------|------|
+| [Curlie](https://curlie.org) | curated directory | hierarchical categories, easy to scrape | manual curation, inconsistent updates |
+| [Wikipedia](https://www.wikipedia.org) | lists & categories | open API, many niche lists | may be incomplete, requires filtering |
+| [Tranco](https://tranco-list.eu) | top sites list | reproducible ranking of the top 1M domains | no categorization |
+| [Open PageRank](https://www.domcop.com/openpagerank/) | API | provides rank metric for domains | rate limits, API key for higher usage |
+| [Common Crawl](https://commoncrawl.org) | massive crawl data | free, comprehensive | large data volume, needs processing |
+
+Commercial APIs (e.g., SimilarWeb, Ahrefs, Moz) could supplement ranking signals but often require paid access.
+
+## Tiering Strategy
+Combine multiple metrics (e.g., Tranco rank percentile, PageRank score) to compute a composite score.  
+Suggested thresholds:
+
+- **S-tier**: top 0.1%
+- **A-tier**: next 0.9%
+- **B-tier**: next 4%
+- **C-tier**: next 15%
+- **D-tier**: next 30%
+- **F-tier**: remainder
+
+These thresholds are illustrative; they should be adjusted based on the distribution of ranking metrics.
+
+## Demo
+Run a quick prototype that fetches a Curlie category and assigns provisional tiers:
+
+```bash
+python build_tiers.py Computers/Internet/On_the_Web/Online_Communities | head
+```
+
+The script marks the first few sites as S/A/B/C/D tiers and places the remainder in F-tier. It serves only as an example until real ranking signals are incorporated.
+
+## Next Steps
+- Expand scraping to additional sources.
+- Store results in structured format (JSON/CSV/DB).
+- Build a small web interface to browse tiers by category.

--- a/tiered_directory/build_tiers.py
+++ b/tiered_directory/build_tiers.py
@@ -1,0 +1,49 @@
+"""Demonstrate simple tier assignment for Curlie category sites.
+
+Usage:
+    python build_tiers.py [category_path]
+
+The first site is marked S-tier, then A/B/C/D tiers get 2/3/4/5 sites
+respectively, with the remainder assigned to F-tier. This is a placeholder
+algorithm until proper ranking metrics are integrated.
+"""
+import sys
+from scrape_curlie import fetch_sites
+
+TIER_COUNTS = [
+    ("S", 1),
+    ("A", 2),
+    ("B", 3),
+    ("C", 4),
+    ("D", 5),
+]
+
+
+def assign_tiers(sites):
+    tiers = {}
+    idx = 0
+    for tier, count in TIER_COUNTS:
+        if idx >= len(sites):
+            break
+        tiers[tier] = sites[idx:idx + count]
+        idx += count
+    if idx < len(sites):
+        tiers["F"] = sites[idx:]
+    return tiers
+
+
+def main():
+    category = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else "Computers/Internet/On_the_Web/Online_Communities"
+    )
+    sites = fetch_sites(category)
+    tiers = assign_tiers(sites)
+    for tier in ["S", "A", "B", "C", "D", "F"]:
+        for site in tiers.get(tier, []):
+            print(f"{tier}: {site['name']} - {site['url']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tiered_directory/scrape_curlie.py
+++ b/tiered_directory/scrape_curlie.py
@@ -1,0 +1,29 @@
+"""Fetch site listings from Curlie for a given category.
+
+Usage:
+    python scrape_curlie.py [category_path]
+Example:
+    python scrape_curlie.py Computers/Internet/On_the_Web/Online_Communities
+"""
+import sys
+import requests
+from bs4 import BeautifulSoup
+
+BASE_URL = "https://curlie.org/en/"
+
+def fetch_sites(category: str):
+    url = BASE_URL + category.strip('/') + '/'
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, 'html.parser')
+    sites = []
+    for td in soup.select('div.title-and-desc'):
+        a = td.find('a', href=True)
+        if a and a['href'].startswith('http'):
+            sites.append({'name': a.get_text(strip=True), 'url': a['href']})
+    return sites
+
+if __name__ == '__main__':
+    category = sys.argv[1] if len(sys.argv) > 1 else 'Computers/Internet/On_the_Web/Online_Communities'
+    for site in fetch_sites(category)[:10]:
+        print(f"{site['name']} - {site['url']}")

--- a/tiered_directory/scrape_wikipedia.py
+++ b/tiered_directory/scrape_wikipedia.py
@@ -1,0 +1,27 @@
+"""Fetch members of a Wikipedia category via MediaWiki API.
+
+Usage:
+    python scrape_wikipedia.py [Category_Name]
+Example:
+    python scrape_wikipedia.py Search_engine_software
+"""
+import sys
+import requests
+
+API_URL = "https://en.wikipedia.org/w/api.php"
+
+def fetch_category_members(category: str, limit: int = 20):
+    params = {
+        'action': 'query',
+        'list': 'categorymembers',
+        'cmtitle': f'Category:{category}',
+        'cmlimit': limit,
+        'format': 'json'
+    }
+    data = requests.get(API_URL, params=params, timeout=10).json()
+    return [m['title'] for m in data.get('query', {}).get('categorymembers', [])]
+
+if __name__ == '__main__':
+    category = sys.argv[1] if len(sys.argv) > 1 else 'Search_engine_software'
+    for title in fetch_category_members(category):
+        print(title)


### PR DESCRIPTION
## Summary
- document approach and potential data sources for building a tiered web directory
- add sample Curlie scraper and Wikipedia category scraper
- add simple demo that assigns provisional tiers based on Curlie listings

## Testing
- `python tiered_directory/scrape_curlie.py | head -n 5`
- `python tiered_directory/scrape_wikipedia.py | head -n 5`
- `python tiered_directory/build_tiers.py | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68935b65021c8332ba28f2a44e371e30